### PR TITLE
Fixing bug with last merge

### DIFF
--- a/reference-apps/iot-trucking-app/trucking-storm-topology/pom.xml
+++ b/reference-apps/iot-trucking-app/trucking-storm-topology/pom.xml
@@ -3,7 +3,6 @@
 	
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	  	<groupId>hortonworks.hdp.refapp.trucking</groupId>
 	  	<artifactId>iot-trucking-app</artifactId>
 	  	<version>5.0.0-SNAPSHOT</version>
@@ -13,6 +12,7 @@
 	
 	
 	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<active.mq.version>5.7.0</active.mq.version>
 		<trucking.domain.objects.version>5.0.0-SNAPSHOT</trucking.domain.objects.version>
 		<mail.version>1.4.3</mail.version>


### PR DESCRIPTION
project.build.sourceEncoding should be under <properties>, not <parent>